### PR TITLE
fix UnknownHostException when visit data with cfs protocol

### DIFF
--- a/src/main/java/io/cubefs/CubefsFileSystem.java
+++ b/src/main/java/io/cubefs/CubefsFileSystem.java
@@ -445,4 +445,10 @@ public class CubefsFileSystem extends FileSystem {
         super.close();
         cfs.closeClient();
     }
+
+    @Override
+    public String getCanonicalServiceName() {
+        // Does not support Token
+        return null;
+    }
 }


### PR DESCRIPTION
It throw a UnknownHostException when I using spark to visit data with path like cfs://${volumnName}/xxx.
The exception is throwed at org.apache.hadoop.security.SecurityUtil.buildTokenService method
![image](https://github.com/cubefs/cubefs-hadoop/assets/4393025/9205bbff-54ce-45d3-a13c-792b480fe11d)

I think that token is not required when visit cubefs, We should refer to the implementation of S3AFileSystem. [S3AFileSystem. getCanonicalServiceName](https://github.com/apache/hadoop/blob/rel/release-3.2.1/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java#L2557)

It works after I overwrite getCanonicalServiceName method.
![image](https://github.com/user-attachments/assets/5979620f-9269-4807-baa9-ceb3bbcdc965)

